### PR TITLE
Rename user table to users to avoid SQL keyword collision

### DIFF
--- a/src/main/java/za/ac/cput/domain/User.java
+++ b/src/main/java/za/ac/cput/domain/User.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "user")
+@Table(name = "users")
 public class User {
 
     @Id


### PR DESCRIPTION
Renames the user table to users per leader's review comment - SQL keyword collision.