### PR TITLE
Fix User entity ID handling and NextOfKinContact linking; add controller tests

### DIFF
--- a/src/main/java/za/ac/cput/domain/User.java
+++ b/src/main/java/za/ac/cput/domain/User.java
@@ -18,7 +18,6 @@ import java.util.List;
 public class User {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     private String userId;
 
     private String firstName;

--- a/src/main/java/za/ac/cput/factory/UserFactory.java
+++ b/src/main/java/za/ac/cput/factory/UserFactory.java
@@ -59,7 +59,9 @@ public class UserFactory {
             userId = Helper.generateId();
         }
 
-        return new User.Builder()
+        List<NextOfKinContact> linkedNextOfKinContacts = new ArrayList<>();
+
+        User user = new User.Builder()
                 .setUserId(userId)
                 .setFirstName(firstName.trim())
                 .setLastName(lastName.trim())
@@ -68,8 +70,22 @@ public class UserFactory {
                 .setDemographic(demographic)
                 .setAddress(address)
                 .setContact(contact)
-                .setNextOfKinContacts(nextOfKinContacts)
+                .setNextOfKinContacts(linkedNextOfKinContacts)
                 .build();
+
+        for (NextOfKinContact nextOfKinContact : nextOfKinContacts) {
+            if (nextOfKinContact == null) {
+                continue;
+            }
+            linkedNextOfKinContacts.add(
+                    new NextOfKinContact.Builder()
+                            .copy(nextOfKinContact)
+                            .setUser(user)
+                            .build()
+            );
+        }
+
+        return user;
     }
 
     public static User createUser(String firstName, String lastName, LocalDate dateOfBirth,

--- a/src/test/java/za/ac/cput/controller/UserControllerTest.java
+++ b/src/test/java/za/ac/cput/controller/UserControllerTest.java
@@ -1,0 +1,176 @@
+package za.ac.cput.controller;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import za.ac.cput.domain.*;
+import za.ac.cput.factory.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * Author: Collins Shibambo
+ * 230093183
+ */
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class UserControllerTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private String baseUrl = "/user";
+
+    private static Account account = AccountFactory.createAccount(
+            "ACC-USER-CTRL-001",
+            "user.controller.test@fitnova.com",
+            "SecurePass123",
+            LocalDate.of(2026, 8, 20)
+    );
+
+    private static Gender gender = GenderFactory.createGender("Female");
+    private static Race race = RaceFactory.createRace("African");
+    private static Demographic demographic = DemographicFactory.createDemographic(gender, race);
+
+    private static Address address = AddressFactory.createAddress(
+            "12", "Long Street", "Gardens", "Cape Town", "8001", "Western Cape", "South Africa"
+    );
+
+    private static Contact contact = ContactFactory.createContact(
+            "0821234567", "0837654321", "user.controller.test@fitnova.com"
+    );
+
+    private static NextOfKinContact nextOfKinContact = new NextOfKinContact.Builder()
+            .setNextOfKinContactId("NOK-CTRL-001")
+            .setFirstName("Zanele")
+            .setLastName("Nkosi")
+            .setRelationship("Sister")
+            .setCellphoneNumber("0837654321")
+            .build();
+
+    private static User user = UserFactory.createUser(
+            "USER-CTRL-001", "Thando", "Nkosi", LocalDate.of(1999, 5, 20),
+            account, demographic, address, contact, List.of(nextOfKinContact)
+    );
+
+    @Test
+    @Order(1)
+    void setupGenderAndRace() {
+        ResponseEntity<Gender> genderResponse = restTemplate.postForEntity("/gender/create", gender, Gender.class);
+        assertNotNull(genderResponse);
+        assertNotNull(genderResponse.getBody());
+        assertEquals(HttpStatus.OK, genderResponse.getStatusCode());
+
+        ResponseEntity<Race> raceResponse = restTemplate.postForEntity("/race/create", race, Race.class);
+        assertNotNull(raceResponse);
+        assertNotNull(raceResponse.getBody());
+        assertEquals(HttpStatus.OK, raceResponse.getStatusCode());
+
+        System.out.println("Setup - created Gender: " + genderResponse.getBody() + ", Race: " + raceResponse.getBody());
+    }
+
+    @Test
+    @Order(2)
+    void create() {
+        String url = baseUrl + "/create";
+        ResponseEntity<User> response = restTemplate.postForEntity(url, user, User.class);
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals("USER-CTRL-001", response.getBody().getUserId());
+        assertEquals(1, response.getBody().getNextOfKinContacts().size());
+        System.out.println("Created: " + response.getBody());
+    }
+
+    @Test
+    @Order(3)
+    void read() {
+        String url = baseUrl + "/read/" + user.getUserId();
+        ResponseEntity<User> response = restTemplate.getForEntity(url, User.class);
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        System.out.println("Read: " + response.getBody());
+    }
+
+    @Test
+    @Order(4)
+    void readNotFound() {
+        String url = baseUrl + "/read/NON-EXISTENT-ID";
+        ResponseEntity<User> response = restTemplate.getForEntity(url, User.class);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    @Order(5)
+    void findByFirstNameAndLastName() {
+        String url = baseUrl + "/findByName/Thando/Nkosi";
+        ResponseEntity<User[]> response = restTemplate.getForEntity(url, User[].class);
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().length > 0);
+        System.out.println("Found by name: " + List.of(response.getBody()));
+    }
+
+    @Test
+    @Order(6)
+    void searchByLastName() {
+        String url = baseUrl + "/searchByLastName/nko";
+        ResponseEntity<User[]> response = restTemplate.getForEntity(url, User[].class);
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().length > 0);
+        System.out.println("Search results: " + List.of(response.getBody()));
+    }
+
+    @Test
+    @Order(7)
+    void update() {
+        String url = baseUrl + "/update";
+        User updatedUser = UserFactory.createUser(
+                "USER-CTRL-001", "Thando", "Dlamini", LocalDate.of(1999, 5, 20),
+                account, demographic, address, contact, List.of(nextOfKinContact)
+        );
+
+        HttpEntity<User> entity = new HttpEntity<>(updatedUser);
+        ResponseEntity<User> response = restTemplate.exchange(url, HttpMethod.PUT, entity, User.class);
+
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Dlamini", response.getBody().getLastName());
+        System.out.println("Updated: " + response.getBody());
+    }
+
+    @Test
+    @Disabled
+    void delete() {
+        String url = baseUrl + "/delete/" + user.getUserId();
+        restTemplate.delete(url);
+        ResponseEntity<User> response = restTemplate.getForEntity(baseUrl + "/read/" + user.getUserId(), User.class);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    @Order(8)
+    void getAll() {
+        String url = baseUrl + "/getAll";
+        ResponseEntity<User[]> response = restTemplate.getForEntity(url, User[].class);
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().length > 0);
+        System.out.println("All Users: " + List.of(response.getBody()));
+    }
+}

--- a/src/test/java/za/ac/cput/controller/UserRoleControllerTest.java
+++ b/src/test/java/za/ac/cput/controller/UserRoleControllerTest.java
@@ -1,0 +1,203 @@
+package za.ac.cput.controller;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import za.ac.cput.domain.*;
+import za.ac.cput.domain.enums.RoleType;
+import za.ac.cput.factory.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * Author: Collins Shibambo
+ * 230093183
+ */
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class UserRoleControllerTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private String userBaseUrl = "/user";
+    private String baseUrl = "/userrole";
+
+    private static Account account = AccountFactory.createAccount(
+            "ACC-ROLE-CTRL-001",
+            "role.controller.test@fitnova.com",
+            "SecurePass123",
+            LocalDate.of(2026, 8, 20)
+    );
+
+    private static Gender gender = GenderFactory.createGender("Male");
+    private static Race race = RaceFactory.createRace("Coloured");
+    private static Demographic demographic = DemographicFactory.createDemographic(gender, race);
+
+    private static Address address = AddressFactory.createAddress(
+            "45", "Main Road", "Observatory", "Cape Town", "7925", "Western Cape", "South Africa"
+    );
+
+    private static Contact contact = ContactFactory.createContact(
+            "0829876543", "0831234567", "role.controller.test@fitnova.com"
+    );
+
+    private static NextOfKinContact nextOfKinContact = new NextOfKinContact.Builder()
+            .setNextOfKinContactId("NOK-ROLE-CTRL-001")
+            .setFirstName("Sipho")
+            .setLastName("Dlamini")
+            .setRelationship("Brother")
+            .setCellphoneNumber("0831234567")
+            .build();
+
+    private static User user = UserFactory.createUser(
+            "USER-ROLE-CTRL-001", "Lindiwe", "Mahlangu", LocalDate.of(1995, 3, 10),
+            account, demographic, address, contact, List.of(nextOfKinContact)
+    );
+
+    private static UserRole userRole = UserRoleFactory.createUserRole(
+            "UR-CTRL-001", user, RoleType.MEMBER, "Standard gym member"
+    );
+
+    @Test
+    @Order(1)
+    void setupGenderAndRace() {
+        ResponseEntity<Gender> genderResponse = restTemplate.postForEntity("/gender/create", gender, Gender.class);
+        assertNotNull(genderResponse);
+        assertNotNull(genderResponse.getBody());
+        assertEquals(HttpStatus.OK, genderResponse.getStatusCode());
+
+        ResponseEntity<Race> raceResponse = restTemplate.postForEntity("/race/create", race, Race.class);
+        assertNotNull(raceResponse);
+        assertNotNull(raceResponse.getBody());
+        assertEquals(HttpStatus.OK, raceResponse.getStatusCode());
+
+        System.out.println("Setup - created Gender: " + genderResponse.getBody() + ", Race: " + raceResponse.getBody());
+    }
+
+    @Test
+    @Order(2)
+    void setupUser() {
+        String url = userBaseUrl + "/create";
+        ResponseEntity<User> response = restTemplate.postForEntity(url, user, User.class);
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals("USER-ROLE-CTRL-001", response.getBody().getUserId());
+        System.out.println("Setup - created User: " + response.getBody());
+    }
+
+    @Test
+    @Order(3)
+    void create() {
+        String url = baseUrl + "/create";
+        ResponseEntity<UserRole> response = restTemplate.postForEntity(url, userRole, UserRole.class);
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals("UR-CTRL-001", response.getBody().getUserRoleId());
+        System.out.println("Created: " + response.getBody());
+    }
+
+    @Test
+    @Order(4)
+    void read() {
+        String url = baseUrl + "/read/" + userRole.getUserRoleId();
+        ResponseEntity<UserRole> response = restTemplate.getForEntity(url, UserRole.class);
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        System.out.println("Read: " + response.getBody());
+    }
+
+    @Test
+    @Order(5)
+    void readNotFound() {
+        String url = baseUrl + "/read/NON-EXISTENT-ID";
+        ResponseEntity<UserRole> response = restTemplate.getForEntity(url, UserRole.class);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    @Order(6)
+    void findByUser() {
+        String url = baseUrl + "/findByUser/" + user.getUserId();
+        ResponseEntity<UserRole[]> response = restTemplate.getForEntity(url, UserRole[].class);
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().length > 0);
+        System.out.println("Found by user: " + List.of(response.getBody()));
+    }
+
+    @Test
+    @Order(7)
+    void findByRole() {
+        String url = baseUrl + "/findByRole/" + RoleType.MEMBER;
+        ResponseEntity<UserRole[]> response = restTemplate.getForEntity(url, UserRole[].class);
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().length > 0);
+        System.out.println("Found by role: " + List.of(response.getBody()));
+    }
+
+    @Test
+    @Order(8)
+    void findByUserAndRole() {
+        String url = baseUrl + "/findByUserAndRole/" + user.getUserId() + "/" + RoleType.MEMBER;
+        ResponseEntity<UserRole> response = restTemplate.getForEntity(url, UserRole.class);
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        System.out.println("Found by user and role: " + response.getBody());
+    }
+
+    @Test
+    @Order(9)
+    void update() {
+        String url = baseUrl + "/update";
+        UserRole updatedUserRole = new UserRole.Builder().copy(userRole)
+                .setDescription("Updated description")
+                .build();
+
+        HttpEntity<UserRole> entity = new HttpEntity<>(updatedUserRole);
+        ResponseEntity<UserRole> response = restTemplate.exchange(url, HttpMethod.PUT, entity, UserRole.class);
+
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Updated description", response.getBody().getDescription());
+        System.out.println("Updated: " + response.getBody());
+    }
+
+    @Test
+    @Disabled
+    void delete() {
+        String url = baseUrl + "/delete/" + userRole.getUserRoleId();
+        restTemplate.delete(url);
+        ResponseEntity<UserRole> response = restTemplate.getForEntity(baseUrl + "/read/" + userRole.getUserRoleId(), UserRole.class);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    @Order(10)
+    void getAll() {
+        String url = baseUrl + "/getAll";
+        ResponseEntity<UserRole[]> response = restTemplate.getForEntity(url, UserRole[].class);
+        assertNotNull(response);
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().length > 0);
+        System.out.println("All UserRoles: " + List.of(response.getBody()));
+    }
+}


### PR DESCRIPTION
Removes GeneratedValue from User so client-supplied IDs are honoured. Restores bidirectional linking in UserFactory so each NextOfKinContact carries its user FK. Adds UserControllerTest and UserRoleControllerTest integration tests - all passing locally.